### PR TITLE
Fix precision bug in MathP36 reconstruction

### DIFF
--- a/src/main/java/org/nintynine/problems/MathP36.java
+++ b/src/main/java/org/nintynine/problems/MathP36.java
@@ -70,8 +70,16 @@ public class MathP36 {
      */
     public static long reconstruct(List<PrimeFactor> factors) {
         return factors.stream()
-                .mapToLong(f -> (long) Math.pow(f.factor, f.multiplicity))
-                .reduce(1L, (a, b) -> a * b);
+                .mapToLong(f -> powLong(f.factor, f.multiplicity))
+                .reduce(1L, Math::multiplyExact);
+    }
+
+    private static long powLong(long base, int exponent) {
+        long result = 1;
+        for (int i = 0; i < exponent; i++) {
+            result = Math.multiplyExact(result, base);
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/org/nintynine/problems/MathP36Test.java
+++ b/src/test/java/org/nintynine/problems/MathP36Test.java
@@ -67,6 +67,15 @@ class MathP36Test {
     }
 
     @Test
+    @DisplayName("Test reconstruction with large numbers")
+    void testReconstructionLarge() {
+        long n = 1_000_000_000_000L;
+        List<MathP36.PrimeFactor> factors = MathP36.primeFactorsMult(n);
+        assertEquals(n, MathP36.reconstruct(factors),
+                "Reconstruction should match original number for large input");
+    }
+
+    @Test
     @DisplayName("Verify factors are prime")
     void verifyFactorsArePrime() {
         long[] testNumbers = {12L, 315L, 1001L, 1024L, 123456L};


### PR DESCRIPTION
## Summary
- fix `reconstruct` to avoid `Math.pow` rounding errors
- add `powLong` helper
- extend tests with a large-number reconstruction case

## Testing
- `./mvnw -q test` *(fails: UnknownHostException repo.maven.apache.org)*