### PR TITLE
Add JMH benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ To run the tests:
 bash ./mvnw test
 ```
 
+### Microbenchmarks
+
+Microbenchmarks are implemented using [JMH](https://openjdk.org/projects/code-tools/jmh/).
+Run them with the JMH plugin:
+
+```bash
+bash ./mvnw jmh:benchmark
+```
+
 ## Implementation Notes
 
 - Each class builds upon previous solutions where appropriate

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.37</jmh.version>
     </properties>
     <build>
         <plugins>
@@ -97,6 +98,19 @@
                     <target>22</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-maven-plugin</artifactId>
+                <version>0.5.2</version>
+                <executions>
+                    <execution>
+                        <id>generate-jmh-sources</id>
+                        <goals>
+                            <goal>generate-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>
@@ -106,6 +120,18 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.13.0-M3</version> <!-- latest as of May 2025 -->
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/nintynine/problems/MathP34Benchmark.java
+++ b/src/test/java/org/nintynine/problems/MathP34Benchmark.java
@@ -1,0 +1,48 @@
+package org.nintynine.problems;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Microbenchmark for {@link MathP34#totientPhi(long)} and
+ * {@link MathP37#totientPhi(long)} using JMH.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MathP34Benchmark {
+
+    /**
+     * Benchmark input state.
+     */
+    @State(Scope.Thread)
+    public static class Input {
+        /**
+         * Numbers for totient calculation.
+         */
+        @Param({"315", "1024", "12345"})
+        public long n;
+    }
+
+    /**
+     * Benchmark the primitive totient implementation.
+     */
+    @Benchmark
+    public long primitiveTotient(Input input) {
+        return MathP34.totientPhi(input.n);
+    }
+
+    /**
+     * Benchmark the improved totient implementation.
+     */
+    @Benchmark
+    public long improvedTotient(Input input) {
+        return MathP37.totientPhi(input.n);
+    }
+}


### PR DESCRIPTION
## Summary
- add JMH dependencies and plugin
- document how to run microbenchmarks
- create `MathP34Benchmark` to measure totient implementations
- correct plugin version for `jmh-generator-maven-plugin`

## Testing
- `./mvnw -q test` *(fails: repo.maven.apache.org UnknownHostException)*