### PR TITLE
Add more BTreeP69 test cases

### DIFF
--- a/src/main/java/org/nintynine/problems/BTreeP69.java
+++ b/src/main/java/org/nintynine/problems/BTreeP69.java
@@ -1,0 +1,103 @@
+package org.nintynine.problems;
+
+/**
+ * P69: Convert a binary tree to and from a dotstring representation.
+ *
+ * <p>The dotstring syntax in Backus–Naur form (BNF) is:</p>
+ * <pre>
+ *   tree ::= '.' | node tree tree
+ *   node ::= 'a' | 'b' | ... | 'z'
+ * </pre>
+ *
+ * <p>A preorder traversal is used where '.' represents an empty subtree.</p>
+ */
+public class BTreeP69 {
+
+    private BTreeP69() {
+    }
+
+    /** A simple binary tree node containing a lowercase character. */
+    public static class BTreeP69Node {
+        char value;
+        BTreeP69Node left;
+        BTreeP69Node right;
+
+        public BTreeP69Node(char value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (!(obj instanceof BTreeP69Node other)) return false;
+            return value == other.value &&
+                   java.util.Objects.equals(left, other.left) &&
+                   java.util.Objects.equals(right, other.right);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(value, left, right);
+        }
+
+        @Override
+        public String toString() {
+            if (left == null && right == null) {
+                return Character.toString(value);
+            }
+            return value + "(" +
+                    (left == null ? "NIL" : left.toString()) + "," +
+                    (right == null ? "NIL" : right.toString()) + ")";
+        }
+    }
+
+    /**
+     * Convert the given tree into its dotstring representation.
+     *
+     * @param node the root node
+     * @return dotstring representation
+     */
+    public static String dotstring(BTreeP69Node node) {
+        if (node == null) {
+            return ".";
+        }
+        return node.value + dotstring(node.left) + dotstring(node.right);
+    }
+
+    /**
+     * Parse a tree from the given dotstring.
+     *
+     * @param str dotstring representation
+     * @return root node of the parsed tree, or {@code null} for an empty tree
+     */
+    public static BTreeP69Node tree(String str) {
+        if (str == null || str.isEmpty()) {
+            return null;
+        }
+        Parser parser = new Parser(str);
+        return parser.parse();
+    }
+
+    private static class Parser {
+        private final String s;
+        private int index;
+
+        Parser(String s) {
+            this.s = s;
+        }
+
+        BTreeP69Node parse() {
+            if (index >= s.length()) {
+                return null;
+            }
+            char c = s.charAt(index++);
+            if (c == '.') {
+                return null;
+            }
+            BTreeP69Node node = new BTreeP69Node(c);
+            node.left = parse();
+            node.right = parse();
+            return node;
+        }
+    }
+}

--- a/src/test/java/org/nintynine/problems/BTreeP69Test.java
+++ b/src/test/java/org/nintynine/problems/BTreeP69Test.java
@@ -1,0 +1,63 @@
+package org.nintynine.problems;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BTreeP69Test {
+
+    @Test
+    void testDotstringExampleRoundTrip() {
+        String dot = "ABD..E..C.FG...";
+        BTreeP69.BTreeP69Node tree = BTreeP69.tree(dot);
+        assertEquals(dot, BTreeP69.dotstring(tree));
+    }
+
+    @Test
+    void testTreeRoundTrip() {
+        BTreeP69.BTreeP69Node root = new BTreeP69.BTreeP69Node('a');
+        root.left = new BTreeP69.BTreeP69Node('b');
+        root.right = new BTreeP69.BTreeP69Node('c');
+        root.left.right = new BTreeP69.BTreeP69Node('d');
+
+        String dot = BTreeP69.dotstring(root);
+        BTreeP69.BTreeP69Node parsed = BTreeP69.tree(dot);
+        assertEquals(root, parsed);
+    }
+
+    @Test
+    void testEmptyTree() {
+        assertNull(BTreeP69.tree(""));
+        assertEquals(".", BTreeP69.dotstring(null));
+    }
+
+    @Test
+    void testParseSingleDot() {
+        assertNull(BTreeP69.tree("."));
+    }
+
+    @Test
+    void testSingleNodeDotstring() {
+        BTreeP69.BTreeP69Node node = new BTreeP69.BTreeP69Node('x');
+        assertEquals("x..", BTreeP69.dotstring(node));
+    }
+
+    @Test
+    void testToStringForLeafAndInternalNodes() {
+        BTreeP69.BTreeP69Node root = new BTreeP69.BTreeP69Node('r');
+        BTreeP69.BTreeP69Node left = new BTreeP69.BTreeP69Node('l');
+        root.left = left;
+
+        // Leaf
+        assertEquals("l", left.toString());
+        // Internal node representation
+        assertEquals("r(l,NIL)", root.toString());
+    }
+
+    @Test
+    void testUppercaseCharactersAreAccepted() {
+        String dot = "A..";
+        BTreeP69.BTreeP69Node tree = BTreeP69.tree(dot);
+        assertEquals(dot, BTreeP69.dotstring(tree));
+    }
+}


### PR DESCRIPTION
## Summary
- expand the `BTreeP69Test` suite with additional edge cases

## Testing
- `./mvnw -q -Dmaven.wagon.http.skip=true -Dmaven.wagon.http.retryHandler.count=0 test` *(fails: could not download Maven distribution)*