### PR TITLE
Implement P69 dotstring conversion

### DIFF
--- a/src/main/java/org/nintynine/problems/BTreeP69.java
+++ b/src/main/java/org/nintynine/problems/BTreeP69.java
@@ -1,0 +1,90 @@
+package org.nintynine.problems;
+
+/**
+ * P69 (**): Dotstring representation of binary trees.
+ * <p>
+ * A binary tree where nodes are identified by single characters can be
+ * represented as a "dotstring" using a preorder traversal in which
+ * null (empty) subtrees are encoded by a dot character '.'.
+ * For example the tree from problem P67 is encoded as
+ * {@code ABD..E..C.FG...}.
+ *
+ * This class provides utility methods to convert between a tree
+ * structure and its dotstring representation.
+ */
+public class BTreeP69 {
+    private BTreeP69() {
+        // utility class
+    }
+
+    /** Node of the binary tree. */
+    public static class Node {
+        char value;
+        Node left;
+        Node right;
+
+        Node(char value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            if (left == null && right == null) {
+                return String.valueOf(value);
+            }
+            return value + "(" +
+                    (left == null ? "NIL" : left.toString()) + "," +
+                    (right == null ? "NIL" : right.toString()) + ")";
+        }
+    }
+
+    /**
+     * Convert a dotstring representation to a tree.
+     *
+     * @param ds the dotstring
+     * @return root node of the parsed tree or {@code null} if dotstring is just '.'
+     * @throws IllegalArgumentException if the dotstring is null or malformed
+     */
+    public static Node tree(String ds) {
+        if (ds == null) {
+            throw new IllegalArgumentException("dotstring cannot be null");
+        }
+        Index index = new Index();
+        Node root = parse(ds, index);
+        if (index.pos != ds.length()) {
+            throw new IllegalArgumentException("Extra characters in dotstring");
+        }
+        return root;
+    }
+
+    private static Node parse(String ds, Index index) {
+        if (index.pos >= ds.length()) {
+            throw new IllegalArgumentException("Incomplete dotstring");
+        }
+        char c = ds.charAt(index.pos++);
+        if (c == '.') {
+            return null;
+        }
+        Node node = new Node(c);
+        node.left = parse(ds, index);
+        node.right = parse(ds, index);
+        return node;
+    }
+
+    /**
+     * Convert a tree into its dotstring representation.
+     *
+     * @param node the root node
+     * @return dotstring encoding
+     */
+    public static String dotstring(Node node) {
+        if (node == null) {
+            return ".";
+        }
+        return node.value + dotstring(node.left) + dotstring(node.right);
+    }
+
+    private static class Index {
+        int pos = 0;
+    }
+}

--- a/src/test/java/org/nintynine/problems/BTreeP69Test.java
+++ b/src/test/java/org/nintynine/problems/BTreeP69Test.java
@@ -1,0 +1,37 @@
+package org.nintynine.problems;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BTreeP69Test {
+
+    @Test
+    void testDotstringExample() {
+        String ds = "ABD..E..C.FG...";
+        BTreeP69.Node tree = BTreeP69.tree(ds);
+        assertEquals(ds, BTreeP69.dotstring(tree));
+    }
+
+    @Test
+    void testSingleNode() {
+        String ds = "A..";
+        BTreeP69.Node tree = BTreeP69.tree(ds);
+        assertEquals('A', tree.value);
+        assertNull(tree.left);
+        assertNull(tree.right);
+        assertEquals(ds, BTreeP69.dotstring(tree));
+    }
+
+    @Test
+    void testNullTree() {
+        assertNull(BTreeP69.tree("."));
+        assertEquals(".", BTreeP69.dotstring(null));
+    }
+
+    @Test
+    void testInvalidDotstring() {
+        assertThrows(IllegalArgumentException.class, () -> BTreeP69.tree("A."));
+        assertThrows(IllegalArgumentException.class, () -> BTreeP69.tree("A..."));
+    }
+}


### PR DESCRIPTION
## Summary
- implement utilities to convert between binary trees and dotstrings
- add unit tests covering dotstring conversions and error cases

## Testing
- `./mvnw test -DtrimStackTrace=false`

------
https://chatgpt.com/codex/tasks/task_e_684e5b069f0083249d1f21b6261af872